### PR TITLE
Add 429 http error and http types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Below is the list of all available errors:
 | GoneError               | 410  | Gone                  |
 | NotFoundError           | 404  | Not Found             |
 | ServiceUnavailableError | 503  | Service Unavailable   |
+| TooManyRequestsError    | 429  | Too Many Requests     |
 | UnauthorizedError       | 401  | Unauthorized          |
 | ValidationFailedError   | 400  | Validation Failed     |
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint"
   ],
   "dependencies": {
-    "standard-http-error": "2.0.0"
+    "@types/standard-http-error": "^2.0.1",
+    "standard-http-error": "2.0.1"
   },
   "devDependencies": {
     "@uphold/github-changelog-generator": "^0.7.0",

--- a/src/errors/too-many-requests-error.js
+++ b/src/errors/too-many-requests-error.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const HttpError = require('./http-error');
+
+/**
+ * Export "Too Many Requests" error.
+ */
+
+module.exports = class TooManyRequestsError extends HttpError {
+  /**
+   * Constructor.
+   */
+
+  constructor() {
+    super(429, ...arguments);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ module.exports = {
   HttpError: require('./errors/http-error'),
   NotFoundError: require('./errors/not-found-error'),
   ServiceUnavailableError: require('./errors/service-unavailable-error'),
+  TooManyRequestsError: require('./errors/too-many-requests-error'),
   UnauthorizedError: require('./errors/unauthorized-error'),
   ValidationFailedError: require('./errors/validation-failed-error')
 };

--- a/test/errors/too-many-requests-error_test.js
+++ b/test/errors/too-many-requests-error_test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { TooManyRequestsError } = require('../../src');
+const test = require('../utils/test-http-error');
+
+/**
+ * Test "TooManyRequestsError" error.
+ */
+
+describe('TooManyRequestsError', () => {
+  test(TooManyRequestsError, 429, 'Too Many Requests');
+});

--- a/types/errors/too-many-requests-error.d.ts
+++ b/types/errors/too-many-requests-error.d.ts
@@ -1,0 +1,5 @@
+import { HttpError } from './http-error';
+export declare class TooManyRequestsError extends HttpError {
+    constructor(message?: string, props?: object);
+    constructor(props?: object);
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,5 +6,6 @@ export * from './errors/gone-error';
 export * from './errors/http-error';
 export * from './errors/not-found-error';
 export * from './errors/service-unavailable-error';
+export * from './errors/too-many-requests-error';
 export * from './errors/unauthorized-error';
 export * from './errors/validation-failed-error';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@types/standard-error@*":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/standard-error/-/standard-error-1.1.0.tgz#7625b53aa5e60ea510b11452bdcc6731b7775bf6"
+  integrity sha512-lZshsx/QFLUJcu9prwm3Gtsl+b38HAqO6XUGH8PGwSmiswQhscd2MKrfk3LX3W3HyvNVUKcpsiuhU9r8DX32ww==
+
+"@types/standard-http-error@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/standard-http-error/-/standard-http-error-2.0.1.tgz#1e63bd8c33bf24890a943d657870477f55bbbad6"
+  integrity sha512-iJkRPfGo0TSFwDW6TxBm5wf+SsBUE9NoRvfeeS2IZcKf3iIX42TLOkzDhSaU6WZ2fUHpN2f5RMYEi+xbBp7eYw==
+  dependencies:
+    "@types/standard-error" "*"
+
 "@uphold/github-changelog-generator@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@uphold/github-changelog-generator/-/github-changelog-generator-0.7.0.tgz#1972dcb8c1d5c32b396d1a8960d98d683e274f3b"
@@ -2455,9 +2467,10 @@ sshpk@^1.7.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/standard-error/-/standard-error-1.1.0.tgz#23e5168fa1c0820189e5812701a79058510d0d34"
 
-standard-http-error@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/standard-http-error/-/standard-http-error-2.0.0.tgz#b59295c13f67fffa4b78973f2e522dc1426b3df5"
+standard-http-error@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-http-error/-/standard-http-error-2.0.1.tgz#f8ae9172e3cef9cb38d2e7084a1925f57a7c34bd"
+  integrity sha512-DX/xPIoyXQTuY6BMZK4Utyi4l3A4vFoafsfqrU6/dO4Oe/59c7PyqPd2IQj9m+ZieDg2K3RL9xOYJsabcD9IUA==
   dependencies:
     standard-error ">= 1.1.0 < 2"
 


### PR DESCRIPTION
## Description

- Add standard http error types, so that `HttpError` can be used correctly in typescript
- Add `TooManyRequestsError` (429)

## Deploy Notes

- A new version should be created and published to NPM